### PR TITLE
Favorite redirect for guests

### DIFF
--- a/web/src/javascript/components/favorite-button.js
+++ b/web/src/javascript/components/favorite-button.js
@@ -1,6 +1,7 @@
 jQuery(function($) {
 
-	var API_URL = '/partial/ajax/add_to_favorites';
+	var REDIR_URL = '/ajax/add_to_favorites';
+	var API_URL = '/partial' + REDIR_URL;
 	var GUEST_URL = '/ws/popup/favorite-guest';
 
 	var CSS_CLASS_GUEST_BUTTON = 'fav_guest';
@@ -119,14 +120,14 @@ jQuery(function($) {
   $('.fav_action_button.fav_guest').on('click touchstart', function(evt) {
     var projectId = $(this).closest('.project').data('id');
     var storeId = $(this).closest('.store').data('id');
-    var guestUrlParams = '?ret='+encodeURIComponent(window.location.pathname);
+    var guestUrlParams = REDIR_URL + '?action=add&redir='+encodeURIComponent(window.location.href);
     if (projectId && !isNaN(projectId)) {
-      guestUrlParams += '&project_id=' + encodeURIComponent(projectId);
+      guestUrlParams += '&project=' + encodeURIComponent(projectId);
     }
     if (storeId && !isNaN(storeId)) {
-      guestUrlParams += '&store_id=' + encodeURIComponent(storeId);
+      guestUrlParams += '&store=' + encodeURIComponent(storeId);
     }
-	  var fullGuestUrl = GUEST_URL + guestUrlParams;
+	  var fullGuestUrl = GUEST_URL + '?ret=' + encodeURIComponent(guestUrlParams);
 
     evt.preventDefault();
 


### PR DESCRIPTION
Currently favoriting stores and projects is not working unless you are logged
in. Previously there was partial support for this, but it required a special
create account component and if you already had an account there was no
corresponding login component.

Since support for a redir parameter has been added to the Add to Favorites CMS
Generator, update favorite-button.js so that if the standard login and create
account components redirect to that the favorite will be set and the user will
be returned to the page they were viewing.

GIV-146 Shouldn't the ability to favorite a store be available for non
logged-in users?